### PR TITLE
Change token account identifier type from Name to accountId

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
+++ b/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
@@ -24,7 +24,7 @@ namespace WorldSeed.Api.Temp
         {
             var claims = new List<Claim>
             {
-                new Claim(ClaimTypes.Name, accountId.ToString())
+                new Claim("accountId", accountId.ToString())
             };
 
             var key = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(


### PR DESCRIPTION
To avoid confusion when working with the token claims.