### PR TITLE
Implement Group service and tests

### DIFF
--- a/Src/Core/WorldSeed.Application/DTOS/ChangeMemberRankDto.cs
+++ b/Src/Core/WorldSeed.Application/DTOS/ChangeMemberRankDto.cs
@@ -1,0 +1,11 @@
+using WorldSeed.Domain.Entities.GroupRelated;
+
+namespace WorldSeed.Application.DTOS
+{
+    public class ChangeMemberRankDto
+    {
+        public int GroupId { get; set; }
+        public int TargetUserId { get; set; }
+        public GroupRank NewRank { get; set; }
+    }
+}

--- a/Src/Core/WorldSeed.Application/DTOS/JoinGroupRequestDto.cs
+++ b/Src/Core/WorldSeed.Application/DTOS/JoinGroupRequestDto.cs
@@ -1,0 +1,7 @@
+namespace WorldSeed.Application.DTOS
+{
+    public class JoinGroupRequestDto
+    {
+        public int GroupId { get; set; }
+    }
+}

--- a/Src/Core/WorldSeed.Application/DTOS/UpdateGroupNameDto.cs
+++ b/Src/Core/WorldSeed.Application/DTOS/UpdateGroupNameDto.cs
@@ -1,0 +1,8 @@
+namespace WorldSeed.Application.DTOS
+{
+    public class UpdateGroupNameDto
+    {
+        public int GroupId { get; set; }
+        public string NewName { get; set; }
+    }
+}

--- a/Src/Core/WorldSeed.Application/Interfaces/IUnitOfWork.cs
+++ b/Src/Core/WorldSeed.Application/Interfaces/IUnitOfWork.cs
@@ -8,6 +8,7 @@ namespace WorldSeed.Application.Interfaces
     {
         IAccountRepository Accounts { get; }
         IGroupRepository Groups { get; }
+        IGroupMemberRepository GroupMembers { get; }
         IUserRepository Users { get; }
 
 

--- a/Src/Core/WorldSeed.Application/Interfaces/Services/IGroupService.cs
+++ b/Src/Core/WorldSeed.Application/Interfaces/Services/IGroupService.cs
@@ -11,5 +11,9 @@ namespace WorldSeed.Application.Interfaces.Services
     public interface IGroupService
     {
         public Group CreateGroup(string name, long userId);
+        public GroupMember JoinGroup(int groupId, long userId);
+        public bool LeaveGroup(int groupId, long userId);
+        public bool UpdateGroupName(int groupId, string newName, long actorUserId);
+        public bool ChangeMemberRank(int groupId, long actorUserId, long targetUserId, GroupRank newRank);
     }
 }

--- a/Src/Core/WorldSeed.Domain/Entities/GroupRelated/GroupMember.cs
+++ b/Src/Core/WorldSeed.Domain/Entities/GroupRelated/GroupMember.cs
@@ -13,6 +13,7 @@ namespace WorldSeed.Domain.Entities.GroupRelated
         public int Id { get; set; }
         public Group Group { get; set; }
         public User User { get; set; }
+        public GroupRank Rank { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
 

--- a/Src/Core/WorldSeed.Domain/Entities/GroupRelated/GroupRank.cs
+++ b/Src/Core/WorldSeed.Domain/Entities/GroupRelated/GroupRank.cs
@@ -1,0 +1,9 @@
+namespace WorldSeed.Domain.Entities.GroupRelated
+{
+    public enum GroupRank
+    {
+        Owner = 0,
+        Admin = 1,
+        Member = 2
+    }
+}

--- a/Src/Core/WorldSeed.Domain/Interfaces/Repositories/IGroupMemberRepository.cs
+++ b/Src/Core/WorldSeed.Domain/Interfaces/Repositories/IGroupMemberRepository.cs
@@ -1,0 +1,9 @@
+using WorldSeed.Domain.Entities.GroupRelated;
+using WorldSeed.Application.Interfaces.Repositories;
+
+namespace WorldSeed.Domain.Interfaces.Repositories
+{
+    public interface IGroupMemberRepository : IRepository<GroupMember>
+    {
+    }
+}

--- a/Src/Infrastructure/WorldSeed.Infrastructure/Data/UnitOfWork.cs
+++ b/Src/Infrastructure/WorldSeed.Infrastructure/Data/UnitOfWork.cs
@@ -17,6 +17,7 @@ namespace WorldSeed.Infrastructure.Data
             _context = context;
             Accounts = new AccountRepository(_context);
             Groups = new GroupRepository(_context);
+            GroupMembers = new GroupMemberRepository(_context);
             Users = new UserRepository(_context);
 
 
@@ -24,6 +25,7 @@ namespace WorldSeed.Infrastructure.Data
 
         public IAccountRepository Accounts { get; private set; }
         public IGroupRepository Groups { get; private set; }
+        public IGroupMemberRepository GroupMembers { get; private set; }
         public IUserRepository Users { get; private set; }
 
         public int SaveChanges()

--- a/Src/Infrastructure/WorldSeed.Infrastructure/Repositories/GroupMemberRepository.cs
+++ b/Src/Infrastructure/WorldSeed.Infrastructure/Repositories/GroupMemberRepository.cs
@@ -1,0 +1,18 @@
+using WorldSeed.Domain.Entities.GroupRelated;
+using WorldSeed.Domain.Interfaces.Repositories;
+using WorldSeed.Infrastructure.Data;
+
+namespace WorldSeed.Infrastructure.Repositories
+{
+    public class GroupMemberRepository : Repository<GroupMember>, IGroupMemberRepository
+    {
+        public GroupMemberRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+
+        ApplicationDbContext ApplicationDbContext
+        {
+            get { return Context as ApplicationDbContext; }
+        }
+    }
+}

--- a/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
@@ -4,11 +4,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using WorldSeed.Application.Interfaces;
+using WorldSeed.Application.Interfaces.Services;
 using WorldSeed.Domain.Entities.GroupRelated;
 
 namespace WorldSeed.Persistence.Services
 {
-    public class GroupService
+    public class GroupService : IGroupService
     {
         private readonly IUnitOfWork _unitOfwork;
 
@@ -19,7 +20,11 @@ namespace WorldSeed.Persistence.Services
 
         public Group CreateGroup(string groupName, long userId)
         {
-            var userFromDB = _unitOfwork.Users.GetAll().Where(u => u.Id.Equals(userId)).FirstOrDefault();
+            var userFromDB = _unitOfwork.Users.GetAll().FirstOrDefault(u => u.Id == userId);
+            if (userFromDB == null)
+            {
+                return null!;
+            }
 
             var newGroup = new Group()
             {
@@ -27,10 +32,122 @@ namespace WorldSeed.Persistence.Services
                 Owner = userFromDB
             };
 
+            var ownerMembership = new GroupMember
+            {
+                Group = newGroup,
+                User = userFromDB,
+                Rank = GroupRank.Owner,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
             _unitOfwork.Groups.Add(newGroup);
+            _unitOfwork.GroupMembers.Add(ownerMembership);
             _unitOfwork.SaveChanges();
 
             return newGroup;
+        }
+
+        public GroupMember JoinGroup(int groupId, long userId)
+        {
+            var group = _unitOfwork.Groups.Get(groupId);
+            var user = _unitOfwork.Users.GetAll().FirstOrDefault(u => u.Id == userId);
+            if (group == null || user == null)
+            {
+                return null;
+            }
+
+            var existing = _unitOfwork.GroupMembers
+                .Find(m => m.Group.Id == groupId && m.User.Id == userId)
+                .FirstOrDefault();
+            if (existing != null)
+            {
+                return null;
+            }
+
+            var membership = new GroupMember()
+            {
+                Group = group,
+                User = user,
+                Rank = GroupRank.Member,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            _unitOfwork.GroupMembers.Add(membership);
+            _unitOfwork.SaveChanges();
+            return membership;
+        }
+
+        public bool LeaveGroup(int groupId, long userId)
+        {
+            var membership = _unitOfwork.GroupMembers
+                .Find(m => m.Group.Id == groupId && m.User.Id == userId)
+                .FirstOrDefault();
+            if (membership == null)
+            {
+                return false;
+            }
+
+            _unitOfwork.GroupMembers.Remove(membership);
+            _unitOfwork.SaveChanges();
+            return true;
+        }
+
+        public bool UpdateGroupName(int groupId, string newName, long actorUserId)
+        {
+            var group = _unitOfwork.Groups.Get(groupId);
+            if (group == null)
+            {
+                return false;
+            }
+
+            var membership = _unitOfwork.GroupMembers
+                .Find(m => m.Group.Id == groupId && m.User.Id == actorUserId)
+                .FirstOrDefault();
+
+            bool canEdit = membership != null && (membership.Rank == GroupRank.Admin || membership.Rank == GroupRank.Owner);
+
+            if (!canEdit)
+            {
+                return false;
+            }
+
+            group.Name = newName;
+            group.UpdatedAt = DateTime.UtcNow;
+            _unitOfwork.SaveChanges();
+            return true;
+        }
+
+        public bool ChangeMemberRank(int groupId, long actorUserId, long targetUserId, GroupRank newRank)
+        {
+            var group = _unitOfwork.Groups.Get(groupId);
+            if (group == null)
+            {
+                return false;
+            }
+
+            var actorMembership = _unitOfwork.GroupMembers
+                .Find(m => m.Group.Id == groupId && m.User.Id == actorUserId)
+                .FirstOrDefault();
+
+            if (actorMembership == null || actorMembership.Rank != GroupRank.Owner)
+            {
+                return false;
+            }
+
+            var target = _unitOfwork.GroupMembers
+                .Find(m => m.Group.Id == groupId && m.User.Id == targetUserId)
+                .FirstOrDefault();
+            if (target == null)
+            {
+                return false;
+            }
+
+            target.Rank = newRank;
+            target.UpdatedAt = DateTime.UtcNow;
+            _unitOfwork.SaveChanges();
+            return true;
         }
     }
 }

--- a/Src/Presentation/WorldSeed.Api/Controllers/GroupController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/GroupController.cs
@@ -45,5 +45,89 @@ namespace WorldSeed.Api.Controllers
 
             return StatusCode(StatusCodes.Status400BadRequest);
         }
+
+        [Authorize]
+        [HttpPost("join")]
+        public StatusCodeResult JoinGroup(JoinGroupRequestDto joinDto)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var result = _groupService.JoinGroup(joinDto.GroupId, account.DefaultUser.Id);
+            if (result != null)
+            {
+                return StatusCode(StatusCodes.Status201Created);
+            }
+            return StatusCode(StatusCodes.Status400BadRequest);
+        }
+
+        [Authorize]
+        [HttpPost("leave")]
+        public StatusCodeResult LeaveGroup(JoinGroupRequestDto dto)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var success = _groupService.LeaveGroup(dto.GroupId, account.DefaultUser.Id);
+            return success ? StatusCode(StatusCodes.Status200OK) : StatusCode(StatusCodes.Status400BadRequest);
+        }
+
+        [Authorize]
+        [HttpPost("updateName")]
+        public StatusCodeResult UpdateGroupName(UpdateGroupNameDto dto)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var success = _groupService.UpdateGroupName(dto.GroupId, dto.NewName, account.DefaultUser.Id);
+            return success ? StatusCode(StatusCodes.Status200OK) : StatusCode(StatusCodes.Status400BadRequest);
+        }
+
+        [Authorize]
+        [HttpPost("rank")]
+        public StatusCodeResult ChangeRank(ChangeMemberRankDto dto)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return StatusCode(StatusCodes.Status400BadRequest);
+            }
+
+            var success = _groupService.ChangeMemberRank(dto.GroupId, account.DefaultUser.Id, dto.TargetUserId, dto.NewRank);
+            return success ? StatusCode(StatusCodes.Status200OK) : StatusCode(StatusCodes.Status400BadRequest);
+        }
     }
 }

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 // Dependency injection
 builder.Services.AddTransient<IAccountService, AccountService>();
 builder.Services.AddTransient<IUserService, UserService>();
+builder.Services.AddTransient<IGroupService, GroupService>();
 
 builder.Services.AddTransient<ITokenService, TokenService>();
 

--- a/Tests/WorldSeed.Tests/GroupServiceTests.cs
+++ b/Tests/WorldSeed.Tests/GroupServiceTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore;
+using WorldSeed.Infrastructure.Data;
+using WorldSeed.Persistence.Services;
+using WorldSeed.Domain.Entities.GroupRelated;
+using WorldSeed.Domain.Entities.UserRelated;
+
+namespace WorldSeed.Tests;
+
+public class GroupServiceTests
+{
+    private static GroupService CreateService(ApplicationDbContext context)
+    {
+        var uow = new UnitOfWork(context);
+        return new GroupService(uow);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Fact]
+    public void CreateGroup_ShouldPersistGroup()
+    {
+        using var context = CreateContext();
+        var user = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        context.Users.Add(user);
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var group = service.CreateGroup("My Group", user.Id);
+
+        Assert.NotNull(group);
+        Assert.Equal("My Group", group.Name);
+        Assert.Equal(1, context.Groups.Count());
+        var membership = context.GroupMembers.FirstOrDefault();
+        Assert.NotNull(membership);
+        Assert.Equal(GroupRank.Owner, membership!.Rank);
+        Assert.Equal(user.Id, membership.User.Id);
+    }
+
+    [Fact]
+    public void JoinGroup_ShouldAddMembership()
+    {
+        using var context = CreateContext();
+        var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        var member = new User { Id = 2, Name = "member", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        context.Users.AddRange(owner, member);
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var group = service.CreateGroup("Group", owner.Id);
+        var membership = service.JoinGroup(group.Id, member.Id);
+
+        Assert.NotNull(membership);
+        Assert.Equal(GroupRank.Member, membership.Rank);
+        Assert.Equal(2, context.GroupMembers.Count());
+    }
+
+    [Fact]
+    public void LeaveGroup_ShouldRemoveMembership()
+    {
+        using var context = CreateContext();
+        var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        var member = new User { Id = 2, Name = "member", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        context.Users.AddRange(owner, member);
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var group = service.CreateGroup("Group", owner.Id);
+        service.JoinGroup(group.Id, member.Id);
+
+        var result = service.LeaveGroup(group.Id, member.Id);
+
+        Assert.True(result);
+        Assert.Single(context.GroupMembers);
+    }
+
+    [Fact]
+    public void UpdateGroupName_ByOwner_ShouldUpdate()
+    {
+        using var context = CreateContext();
+        var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        context.Users.Add(owner);
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var group = service.CreateGroup("Old", owner.Id);
+
+        var result = service.UpdateGroupName(group.Id, "New", owner.Id);
+
+        Assert.True(result);
+        Assert.Equal("New", context.Groups.First().Name);
+    }
+
+    [Fact]
+    public void ChangeMemberRank_ByOwner_ShouldUpdateRank()
+    {
+        using var context = CreateContext();
+        var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        var member = new User { Id = 2, Name = "member", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        context.Users.AddRange(owner, member);
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var group = service.CreateGroup("Group", owner.Id);
+        service.JoinGroup(group.Id, member.Id);
+
+        var result = service.ChangeMemberRank(group.Id, owner.Id, member.Id, GroupRank.Admin);
+
+        Assert.True(result);
+        var updated = context.GroupMembers.First(m => m.User.Id == member.Id);
+        Assert.Equal(GroupRank.Admin, updated.Rank);
+    }
+}

--- a/Tests/WorldSeed.Tests/WorldSeed.Tests.csproj
+++ b/Tests/WorldSeed.Tests/WorldSeed.Tests.csproj
@@ -20,10 +20,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="../../Src/Common/WorldSeed.Common/WorldSeed.Common.csproj" />
+    <ProjectReference Include="../../Src/Core/WorldSeed.Domain/WorldSeed.Domain.csproj" />
+    <ProjectReference Include="../../Src/Core/WorldSeed.Application/WorldSeed.Application.csproj" />
+    <ProjectReference Include="../../Src/Infrastructure/WorldSeed.Infrastructure/WorldSeed.Infrastructure.csproj" />
+    <ProjectReference Include="../../Src/Infrastructure/WorldSeed.Persistence/WorldSeed.Persistence.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- implement ownership membership when creating a group
- manage group permissions using `GroupMember` records
- add comprehensive unit tests for group operations
- include EF InMemory package in test project

## Testing
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684dfea7de18832da5bbe17800b7ce49