### PR TITLE
Fix nullable warnings without #nullable

### DIFF
--- a/Src/Core/WorldSeed.Domain/Entities/GroupRelated/Group.cs
+++ b/Src/Core/WorldSeed.Domain/Entities/GroupRelated/Group.cs
@@ -12,8 +12,8 @@ namespace WorldSeed.Domain.Entities.GroupRelated
     public class Group
     {
         public int Id { get; set; }
-        public User Owner { get; set; }
-        public string Name { get; set; }
+        public required User Owner { get; set; }
+        public required string Name { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
     }


### PR DESCRIPTION
## Summary
- remove project nullable settings from non-web projects
- make group entity properties required
- clean up `Forum` and `Group` entity files

## Testing
- `dotnet build Src/WorldSeed.sln --configuration Release`
- `dotnet test Tests/WorldSeed.Tests/WorldSeed.Tests.csproj -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684e0bcba8f8832d932ca60833028176