### PR TITLE
Add service unit tests

### DIFF
--- a/Tests/WorldSeed.Tests/AccountServiceTests.cs
+++ b/Tests/WorldSeed.Tests/AccountServiceTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.EntityFrameworkCore;
+using System.Security.Cryptography;
+using WorldSeed.Domain.Entities.AccountRelated;
+using WorldSeed.Infrastructure.Data;
+using WorldSeed.Persistence.Services;
+
+namespace WorldSeed.Tests;
+
+public class AccountServiceTests
+{
+    private static AccountService CreateService(ApplicationDbContext context)
+    {
+        var uow = new UnitOfWork(context);
+        return new AccountService(uow);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    private static (byte[] hash, byte[] salt) Hash(string password)
+    {
+        using var hmac = new HMACSHA512();
+        return (hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password)), hmac.Key);
+    }
+
+    [Fact]
+    public void CreateAccount_ShouldPersistAccount()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        Assert.NotNull(account);
+        Assert.Equal(1, context.Accounts.Count());
+    }
+
+    [Fact]
+    public void CheckLoginByEmail_WithValidCredentials_ReturnsAccount()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        var result = service.CheckLoginByEmail("user@example.com", "pass");
+
+        Assert.NotNull(result);
+        Assert.Equal(account.Id, result!.Id);
+    }
+
+    [Fact]
+    public void GetAccountById_ReturnsAccount()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        var fetched = service.GetAccountById(account.Id);
+
+        Assert.NotNull(fetched);
+        Assert.Equal(account.UserName, fetched!.UserName);
+    }
+
+    [Fact]
+    public void GetAccountByEmail_ReturnsAccount()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        var fetched = service.GetAccountByEmail("user@example.com");
+
+        Assert.NotNull(fetched);
+        Assert.Equal(account.Id, fetched!.Id);
+    }
+
+    [Fact]
+    public void GetAccountByUsername_ReturnsAccount()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        var fetched = service.GetAccountByUsername("user");
+
+        Assert.NotNull(fetched);
+        Assert.Equal(account.Id, fetched!.Id);
+    }
+
+    [Fact]
+    public void UpdateTokens_SetsRefreshTokenData()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        var expires = DateTime.UtcNow.AddHours(1);
+        var created = DateTime.UtcNow;
+        service.UpdateTokens(account.Id, "token", expires, created);
+
+        var refreshed = context.Accounts.First();
+        Assert.Equal("token", refreshed.RefreshToken);
+        Assert.Equal(expires, refreshed.TokenExpires);
+        Assert.Equal(created, refreshed.TokenCreated);
+    }
+}
+

--- a/Tests/WorldSeed.Tests/TokenServiceTests.cs
+++ b/Tests/WorldSeed.Tests/TokenServiceTests.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Configuration;
+using WorldSeed.Api.Temp;
+using WorldSeed.Application.Interfaces.Services;
+using WorldSeed.Application.DTOS;
+using WorldSeed.Domain.Entities.AccountRelated;
+
+namespace WorldSeed.Tests;
+
+public class TokenServiceTests
+{
+    private class StubAccountService : IAccountService
+    {
+        private readonly Account _account;
+
+        public StubAccountService(Account account)
+        {
+            _account = account;
+        }
+
+        public Account GetAccountById(int accountId) => _account;
+        public Account CreateAccount(string username, string email, byte[] passwordHash, byte[] passwordSalt) => throw new NotImplementedException();
+        public Account CheckLoginByEmail(string email, string password) => throw new NotImplementedException();
+        public Account GetAccountByEmail(string email) => throw new NotImplementedException();
+        public Account GetAccountByUsername(string username) => throw new NotImplementedException();
+        public void UpdateTokens(int accountId, string refreshToken, DateTime expires, DateTime created) => throw new NotImplementedException();
+    }
+
+    private static TokenService CreateService(Account account)
+    {
+        var settings = new Dictionary<string, string> { { "AppSettings:Token", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } };
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        var accSvc = new StubAccountService(account);
+        return new TokenService(config, accSvc);
+    }
+
+    [Fact]
+    public void CreateToken_ReturnsTokenDTO()
+    {
+        var service = CreateService(new Account());
+
+        var token = service.CreateToken(1);
+
+        Assert.False(string.IsNullOrWhiteSpace(token.Token));
+        Assert.True(token.ValidTo > token.ValidFrom);
+    }
+
+    [Fact]
+    public void GenerateRefreshToken_ReturnsValidDTO()
+    {
+        var service = CreateService(new Account());
+
+        var refresh = service.GenerateRefreshToken();
+
+        Assert.False(string.IsNullOrWhiteSpace(refresh.Token));
+        Assert.True(refresh.Expires > DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void IsRefreshTokenValid_WithValidToken_ReturnsTrue()
+    {
+        var account = new Account
+        {
+            RefreshToken = "abc",
+            TokenExpires = DateTime.UtcNow.AddMinutes(5)
+        };
+        var service = CreateService(account);
+
+        Assert.True(service.IsRefreshTokenValid(1, "abc"));
+    }
+
+    [Fact]
+    public void IsRefreshTokenValid_WithInvalidToken_ReturnsFalse()
+    {
+        var account = new Account
+        {
+            RefreshToken = "abc",
+            TokenExpires = DateTime.UtcNow.AddMinutes(-1)
+        };
+        var service = CreateService(account);
+
+        Assert.False(service.IsRefreshTokenValid(1, "abc"));
+        Assert.False(service.IsRefreshTokenValid(1, "other"));
+    }
+}
+

--- a/Tests/WorldSeed.Tests/UserServiceTests.cs
+++ b/Tests/WorldSeed.Tests/UserServiceTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore;
+using WorldSeed.Domain.Entities.AccountRelated;
+using WorldSeed.Domain.Entities.UserRelated;
+using WorldSeed.Infrastructure.Data;
+using WorldSeed.Persistence.Services;
+
+namespace WorldSeed.Tests;
+
+public class UserServiceTests
+{
+    private static UserService CreateService(ApplicationDbContext context)
+    {
+        var uow = new UnitOfWork(context);
+        return new UserService(uow);
+    }
+
+    private static ApplicationDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
+    [Fact]
+    public void CreateUser_ShouldPersistUser()
+    {
+        using var context = CreateContext();
+        var account = new Account { Id = 1, UserName = "user", Email = "e" };
+        context.Accounts.Add(account);
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var user = service.CreateUser(account.Id, "name");
+
+        Assert.NotNull(user);
+        Assert.Equal(1, context.Users.Count());
+        Assert.Equal(account.Id, context.Users.First().Account.Id);
+    }
+
+    [Fact]
+    public void CreateUser_DuplicateName_ReturnsNull()
+    {
+        using var context = CreateContext();
+        var account = new Account { Id = 1, UserName = "user", Email = "e" };
+        context.Accounts.Add(account);
+        context.Users.Add(new User { Account = account, Name = "name", CreatedAt = DateTime.UtcNow });
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var user = service.CreateUser(account.Id, "name");
+
+        Assert.Null(user);
+    }
+
+    [Fact]
+    public void GetUsersbyAccountId_ReturnsUsers()
+    {
+        using var context = CreateContext();
+        var acc1 = new Account { Id = 1, UserName = "a1", Email = "a1" };
+        var acc2 = new Account { Id = 2, UserName = "a2", Email = "a2" };
+        context.Accounts.AddRange(acc1, acc2);
+        context.Users.AddRange(
+            new User { Account = acc1, Name = "u1", CreatedAt = DateTime.UtcNow },
+            new User { Account = acc1, Name = "u2", CreatedAt = DateTime.UtcNow },
+            new User { Account = acc2, Name = "u3", CreatedAt = DateTime.UtcNow }
+        );
+        context.SaveChanges();
+        var service = CreateService(context);
+
+        var result = service.GetUsersbyAccountId(acc1.Id);
+
+        Assert.Equal(2, result.Count);
+    }
+}
+

--- a/Tests/WorldSeed.Tests/WorldSeed.Tests.csproj
+++ b/Tests/WorldSeed.Tests/WorldSeed.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="../../Src/Core/WorldSeed.Application/WorldSeed.Application.csproj" />
     <ProjectReference Include="../../Src/Infrastructure/WorldSeed.Infrastructure/WorldSeed.Infrastructure.csproj" />
     <ProjectReference Include="../../Src/Infrastructure/WorldSeed.Persistence/WorldSeed.Persistence.csproj" />
+    <ProjectReference Include="../../Src/Presentation/WorldSeed.Api/WorldSeed.Api.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add AccountService unit tests
- add UserService unit tests
- add TokenService unit tests
- reference API project in test project
- keep repo SDK at 8.0.203

## Testing
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684e107d77d4832db33a9dd9ba951c72