### PR TITLE
Add configurable API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ As a developer I dislike reinventing the wheel every time I am assigned to work 
 - JWT bearer token authentication
 - REST API
 - Cross platform
+- API base URL configurable via `ApiSettings:Url` in `appsettings.json`
 
 # Web client for the API
 https://github.com/Y-Kilic/Worldseed.Client.Blazor

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -14,9 +14,10 @@ using WorldSeed.Infrastructure.Repositories;
 using WorldSeed.Persistence;
 using WorldSeed.Persistence.Services;
 
+var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
 var initialConfig = new ConfigurationBuilder()
     .AddJsonFile("appsettings.json", optional: true)
-    .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable(\"ASPNETCORE_ENVIRONMENT\")}.json", optional: true)
+    .AddJsonFile($"appsettings.{environmentName}.json", optional: true)
     .AddEnvironmentVariables()
     .Build();
 

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters;
 using System.Text;
+using Microsoft.Extensions.Configuration;
 using WorldSeed.Api.Temp;
 using WorldSeed.Application.Interfaces;
 using WorldSeed.Application.Interfaces.Services;
@@ -12,6 +13,18 @@ using WorldSeed.Infrastructure.Data;
 using WorldSeed.Infrastructure.Repositories;
 using WorldSeed.Persistence;
 using WorldSeed.Persistence.Services;
+
+var initialConfig = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable(\"ASPNETCORE_ENVIRONMENT\")}.json", optional: true)
+    .AddEnvironmentVariables()
+    .Build();
+
+var apiUrl = initialConfig.GetValue<string>("ApiSettings:Url");
+if (!string.IsNullOrWhiteSpace(apiUrl))
+{
+    Environment.SetEnvironmentVariable("ASPNETCORE_URLS", apiUrl);
+}
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/Src/Presentation/WorldSeed.Api/Properties/launchSettings.json
+++ b/Src/Presentation/WorldSeed.Api/Properties/launchSettings.json
@@ -14,7 +14,6 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7048;http://localhost:5048",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Src/Presentation/WorldSeed.Api/appsettings.Development.json
+++ b/Src/Presentation/WorldSeed.Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ApiSettings": {
+    "Url": "https://localhost:7048;http://localhost:5048"
   }
 }

--- a/Src/Presentation/WorldSeed.Api/appsettings.json
+++ b/Src/Presentation/WorldSeed.Api/appsettings.json
@@ -2,6 +2,9 @@
   "AppSettings": {
     "Token": "REPLACEp8QGgjVyP9gkAAyTDD04POfaRGeeVB3hDQNMEF832ft6oC1-JjcYsoOAcb4p-CR5RHpYzyXNdvGhKYA"
   },
+  "ApiSettings": {
+    "Url": "https://localhost:7048;http://localhost:5048"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- support `ApiSettings:Url` in API config
- set Kestrel `ASPNETCORE_URLS` using the config value
- mention new setting in README
- remove hardcoded URL from launch settings

## Testing
- `dotnet test Src/WorldSeed.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee68d6400832da5dba977a85c5a6c