### PR TITLE
Improve group APIs and restrict forum creation

### DIFF
--- a/Src/Core/WorldSeed.Application/DTOS/GroupDto.cs
+++ b/Src/Core/WorldSeed.Application/DTOS/GroupDto.cs
@@ -1,0 +1,8 @@
+namespace WorldSeed.Application.DTOS
+{
+    public class GroupDto
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Src/Core/WorldSeed.Application/DTOS/GroupMemberDto.cs
+++ b/Src/Core/WorldSeed.Application/DTOS/GroupMemberDto.cs
@@ -1,0 +1,11 @@
+using WorldSeed.Domain.Entities.GroupRelated;
+
+namespace WorldSeed.Application.DTOS
+{
+    public class GroupMemberDto
+    {
+        public int UserId { get; set; }
+        public string UserName { get; set; }
+        public GroupRank Rank { get; set; }
+    }
+}

--- a/Src/Core/WorldSeed.Application/Interfaces/Services/IGroupService.cs
+++ b/Src/Core/WorldSeed.Application/Interfaces/Services/IGroupService.cs
@@ -15,5 +15,8 @@ namespace WorldSeed.Application.Interfaces.Services
         public bool LeaveGroup(int groupId, long userId);
         public bool UpdateGroupName(int groupId, string newName, long actorUserId);
         public bool ChangeMemberRank(int groupId, long actorUserId, long targetUserId, GroupRank newRank);
+        public IEnumerable<Group> GetGroupsForUser(long userId);
+        public IEnumerable<Group> GetJoinableGroups(long userId);
+        public IEnumerable<GroupMember> GetGroupMembers(int groupId);
     }
 }

--- a/Src/Infrastructure/WorldSeed.Persistence/Services/ForumService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/ForumService.cs
@@ -19,24 +19,27 @@ namespace WorldSeed.Persistence.Services
 
         public bool CreateForum(CreateForumDTO createForumDTO)
         {
+            if (!createForumDTO.GroupId.HasValue)
+            {
+                return false;
+            }
+
+            var group = _unitOfWork.Groups.Get(createForumDTO.GroupId.Value);
+            if (group == null)
+            {
+                return false;
+            }
+
             var forum = new Forum
             {
                 Name = createForumDTO.Name,
+                Group = group,
+                GroupId = group.Id,
                 CreatedAt = DateTime.UtcNow,
                 UpdatedAt = DateTime.UtcNow
             };
 
-            if (createForumDTO.GroupId.HasValue)
-            {
-                var group = _unitOfWork.Groups.Get(createForumDTO.GroupId.Value);
-                if (group == null)
-                {
-                    return false;
-                }
-                forum.Group = group;
-                forum.GroupId = group.Id;
-                group.Forum = forum;
-            }
+            group.Forum = forum;
 
             _unitOfWork.Forums.Add(forum);
             _unitOfWork.SaveChanges();

--- a/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
@@ -162,5 +162,28 @@ namespace WorldSeed.Persistence.Services
             _unitOfwork.SaveChanges();
             return true;
         }
+
+        public IEnumerable<Group> GetGroupsForUser(long userId)
+        {
+            return _unitOfwork.GroupMembers
+                .Find(m => m.User.Id == userId)
+                .Select(m => m.Group);
+        }
+
+        public IEnumerable<Group> GetJoinableGroups(long userId)
+        {
+            var joinedIds = _unitOfwork.GroupMembers
+                .Find(m => m.User.Id == userId)
+                .Select(m => m.Group.Id)
+                .ToHashSet();
+
+            return _unitOfwork.Groups.GetAll()
+                .Where(g => !joinedIds.Contains(g.Id));
+        }
+
+        public IEnumerable<GroupMember> GetGroupMembers(int groupId)
+        {
+            return _unitOfwork.GroupMembers.Find(m => m.Group.Id == groupId);
+        }
     }
 }

--- a/Src/Presentation/WorldSeed.Api/Controllers/ForumController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/ForumController.cs
@@ -20,12 +20,12 @@ namespace WorldSeed.Api.Controllers
         [HttpPost("createForum")]
         public StatusCodeResult CreateGroup(CreateForumDTO createForumDTO)
         {
-            if (_forumService.CreateForum(createForumDTO))
+            if (!_forumService.CreateForum(createForumDTO))
             {
-                return StatusCode(StatusCodes.Status201Created);
+                return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            return StatusCode(StatusCodes.Status400BadRequest);
+            return StatusCode(StatusCodes.Status201Created);
         }
 
         [HttpPost("createCategory")]

--- a/Src/Presentation/WorldSeed.Api/Controllers/GroupController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/GroupController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using System.Linq;
 using WorldSeed.Application.DTOS;
 using WorldSeed.Application.Interfaces.Services;
 using WorldSeed.Domain.Entities.GroupRelated;
@@ -44,6 +45,71 @@ namespace WorldSeed.Api.Controllers
             }
 
             return StatusCode(StatusCodes.Status400BadRequest);
+        }
+
+        [Authorize]
+        [HttpGet("mine")]
+        public IEnumerable<GroupDto> GetMyGroups()
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return Enumerable.Empty<GroupDto>();
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return Enumerable.Empty<GroupDto>();
+            }
+
+            return _groupService.GetGroupsForUser(account.DefaultUser.Id)
+                .Select(g => new GroupDto { Id = g.Id, Name = g.Name });
+        }
+
+        [Authorize]
+        [HttpGet("joinable")]
+        public IEnumerable<GroupDto> GetJoinableGroups()
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return Enumerable.Empty<GroupDto>();
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return Enumerable.Empty<GroupDto>();
+            }
+
+            return _groupService.GetJoinableGroups(account.DefaultUser.Id)
+                .Select(g => new GroupDto { Id = g.Id, Name = g.Name });
+        }
+
+        [Authorize]
+        [HttpGet("{groupId}/members")]
+        public IEnumerable<GroupMemberDto> GetGroupMembers(int groupId)
+        {
+            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
+            if (!int.TryParse(claimValue, out var accountId))
+            {
+                return Enumerable.Empty<GroupMemberDto>();
+            }
+
+            var account = _accountService.GetAccountById(accountId);
+            if (account == null || account.DefaultUser == null)
+            {
+                return Enumerable.Empty<GroupMemberDto>();
+            }
+
+            return _groupService.GetGroupMembers(groupId)
+                .Select(m => new GroupMemberDto
+                {
+                    UserId = m.User.Id,
+                    UserName = m.User.Name,
+                    Rank = m.Rank
+                });
         }
 
         [Authorize]

--- a/Tests/WorldSeed.Tests/ForumServiceTests.cs
+++ b/Tests/WorldSeed.Tests/ForumServiceTests.cs
@@ -24,18 +24,15 @@ public class ForumServiceTests
     }
 
     [Fact]
-    public void CreateForum_NoGroup_ShouldPersistForum()
+    public void CreateForum_NoGroup_ShouldFail()
     {
         using var context = CreateContext();
         var service = CreateService(context);
 
         var result = service.CreateForum(new CreateForumDTO { Name = "Test" });
 
-        Assert.True(result);
-        Assert.Equal(1, context.Forums.Count());
-        var forum = context.Forums.First();
-        Assert.Equal("Test", forum.Name);
-        Assert.Null(forum.Group);
+        Assert.False(result);
+        Assert.Empty(context.Forums);
     }
 
     [Fact]
@@ -73,9 +70,13 @@ public class ForumServiceTests
     public void CreateCategory_ShouldPersist()
     {
         using var context = CreateContext();
+        var user = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        var group = new Group { Id = 1, Name = "grp", Owner = user, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        context.Users.Add(user);
+        context.Groups.Add(group);
+        context.SaveChanges();
         var service = CreateService(context);
-        var forumDto = new CreateForumDTO { Name = "Forum" };
-        service.CreateForum(forumDto);
+        service.CreateForum(new CreateForumDTO { Name = "Forum", GroupId = group.Id });
         var forum = context.Forums.First();
 
         var category = service.CreateCategory(new CreateForumCategoryDTO { ForumId = forum.Id, Name = "General" });
@@ -90,10 +91,12 @@ public class ForumServiceTests
     {
         using var context = CreateContext();
         var user = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        var group = new Group { Id = 1, Name = "grp", Owner = user, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
         context.Users.Add(user);
+        context.Groups.Add(group);
         context.SaveChanges();
         var service = CreateService(context);
-        service.CreateForum(new CreateForumDTO { Name = "Forum" });
+        service.CreateForum(new CreateForumDTO { Name = "Forum", GroupId = group.Id });
         var forum = context.Forums.First();
         var category = service.CreateCategory(new CreateForumCategoryDTO { ForumId = forum.Id, Name = "General" });
 
@@ -109,10 +112,12 @@ public class ForumServiceTests
     {
         using var context = CreateContext();
         var user = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        var group = new Group { Id = 1, Name = "grp", Owner = user, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
         context.Users.Add(user);
+        context.Groups.Add(group);
         context.SaveChanges();
         var service = CreateService(context);
-        service.CreateForum(new CreateForumDTO { Name = "Forum" });
+        service.CreateForum(new CreateForumDTO { Name = "Forum", GroupId = group.Id });
         var forum = context.Forums.First();
         var category = service.CreateCategory(new CreateForumCategoryDTO { ForumId = forum.Id, Name = "General" });
         var thread = service.CreateThread(new CreateForumThreadDTO { ForumCategoryId = category.Id, OwnerId = user.Id, Title = "Welcome" });


### PR DESCRIPTION
## Summary
- add DTOs for group listing and member info
- extend `IGroupService` and implement new methods for listing groups and members
- expose new endpoints in `GroupController` to fetch user's groups, joinable groups, and members
- restrict forum creation to require a group and adjust controller logic
- update tests accordingly

## Testing
- `dotnet test Src/WorldSeed.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef042638c832da54b5ae57f82bae8