### PR TITLE
Fix JWT name claim and enable authentication

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
+++ b/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
@@ -24,7 +24,8 @@ namespace WorldSeed.Api.Temp
         {
             var claims = new List<Claim>
             {
-                new Claim("accountId", accountId.ToString())
+                new Claim("accountId", accountId.ToString()),
+                new Claim("name", accountId.ToString())
             };
 
             var key = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -61,6 +61,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             RoleClaimType= "role",
         };
     });
+builder.Services.AddAuthorization();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
          options.UseInMemoryDatabase(databaseName: "Test"));
 
@@ -99,9 +100,9 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-//app.UseAuthentication();
+app.UseAuthentication();
 
-//app.UseAuthorization();
+app.UseAuthorization();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- add `name` claim when generating JWT tokens so `ClaimTypes.Name` resolves to the account id
- register authorization services and enable authentication/authorization middleware

## Testing
- `dotnet test Src/WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851d4fd2ac4832d8eb43739c74ec47f