### PR TITLE
Fix name claim mapping for JWT

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -57,10 +57,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .GetBytes(builder.Configuration.GetSection("AppSettings:Token").Value ?? string.Empty)),
             ValidateIssuer = false,
             ValidateAudience = false,
-            NameClaimType = "name",
+            NameClaimType = "accountId",
             RoleClaimType= "role",
         };
     });
+builder.Services.AddAuthorization();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
          options.UseInMemoryDatabase(databaseName: "Test"));
 
@@ -99,9 +100,9 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-//app.UseAuthentication();
+app.UseAuthentication();
 
-//app.UseAuthorization();
+app.UseAuthorization();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- map `accountId` claim as the name identifier
- remove extra `name` claim from JWT generation

## Testing
- `dotnet test Src/WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851d4fd2ac4832d8eb43739c74ec47f