### PR TITLE
Fix missing ClaimTypes.Name for JWT

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
+++ b/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
@@ -24,7 +24,8 @@ namespace WorldSeed.Api.Temp
         {
             var claims = new List<Claim>
             {
-                new Claim("accountId", accountId.ToString())
+                new Claim("accountId", accountId.ToString()),
+                new Claim(ClaimTypes.Name, accountId.ToString())
             };
 
             var key = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters;
 using System.Text;
+using System.Security.Claims;
 using Microsoft.Extensions.Configuration;
 using WorldSeed.Api.Temp;
 using WorldSeed.Application.Interfaces;
@@ -57,10 +58,11 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .GetBytes(builder.Configuration.GetSection("AppSettings:Token").Value ?? string.Empty)),
             ValidateIssuer = false,
             ValidateAudience = false,
-            NameClaimType = "name",
+            NameClaimType = ClaimTypes.Name,
             RoleClaimType= "role",
         };
     });
+builder.Services.AddAuthorization();
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
          options.UseInMemoryDatabase(databaseName: "Test"));
 
@@ -99,9 +101,9 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-//app.UseAuthentication();
+app.UseAuthentication();
 
-//app.UseAuthorization();
+app.UseAuthorization();
 
 app.MapControllers();
 


### PR DESCRIPTION
## Summary
- add ClaimTypes.Name claim when issuing JWT tokens
- configure JWT validation to map ClaimTypes.Name
- enable authentication middleware

## Testing
- `dotnet test Src/WorldSeed.sln`


------
https://chatgpt.com/codex/tasks/task_e_6851d4fd2ac4832d8eb43739c74ec47f