### PR TITLE
Fix claim retrieval in API controllers

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Controllers/AuthController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/AuthController.cs
@@ -1,9 +1,8 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using System.Security.Cryptography;
 using WorldSeed.Api.Temp;
 using WorldSeed.Application.DTOS;
@@ -91,8 +90,8 @@ namespace WorldSeed.Api.Controllers
         public ActionResult<RefreshTokenResponseDTO> RefreshToken(RefreshTokenRequestDTO refreshTokenRequestDTO)
         {
 
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var currentUserId))
+            var claim = Request.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "accountId");
+            if (claim == null || !int.TryParse(claim.Value, out var currentUserId))
             {
                 return BadRequest("Refreshtoken not valid.");
 

--- a/Src/Presentation/WorldSeed.Api/Controllers/ForumController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/ForumController.cs
@@ -1,7 +1,6 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
-using System.Security.Claims;
 using WorldSeed.Application.DTOS;
 using WorldSeed.Application.Interfaces.Services;
 using WorldSeed.Domain.Entities.ForumRelated;
@@ -51,8 +50,8 @@ namespace WorldSeed.Api.Controllers
         {
             if (dto.OwnerId <= 0)
             {
-                var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-                if (int.TryParse(claimValue, out var accountId))
+                var claim = Request.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "accountId");
+                if (claim != null && int.TryParse(claim.Value, out var accountId))
                 {
                     var account = _accountService.GetAccountById(accountId);
                     if (account != null && account.DefaultUser != null)
@@ -76,8 +75,8 @@ namespace WorldSeed.Api.Controllers
         {
             if (dto.OwnerId <= 0)
             {
-                var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-                if (int.TryParse(claimValue, out var accountId))
+                var claim = Request.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "accountId");
+                if (claim != null && int.TryParse(claim.Value, out var accountId))
                 {
                     var account = _accountService.GetAccountById(accountId);
                     if (account != null && account.DefaultUser != null)

--- a/Src/Presentation/WorldSeed.Api/Controllers/GroupController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/GroupController.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
 using System.Linq;
 using WorldSeed.Application.DTOS;
 using WorldSeed.Application.Interfaces.Services;
@@ -21,17 +20,28 @@ namespace WorldSeed.Api.Controllers
             _accountService = accountService;
         }
 
+        private int? GetAccountIdFromClaims()
+        {
+            var claim = Request.HttpContext.User.Claims.FirstOrDefault(c => c.Type == "accountId");
+            if (claim == null || !int.TryParse(claim.Value, out var accountId))
+            {
+                return null;
+            }
+
+            return accountId;
+        }
+
         [Authorize]
         [HttpPost("createGroup")]
         public StatusCodeResult CreateGroup(CreateGroupRequestDto createGroupRequestDto)
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var currentAccountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            var account = _accountService.GetAccountById(currentAccountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
@@ -51,13 +61,13 @@ namespace WorldSeed.Api.Controllers
         [HttpGet("mine")]
         public IEnumerable<GroupDto> GetMyGroups()
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return Enumerable.Empty<GroupDto>();
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return Enumerable.Empty<GroupDto>();
@@ -71,13 +81,13 @@ namespace WorldSeed.Api.Controllers
         [HttpGet("joinable")]
         public IEnumerable<GroupDto> GetJoinableGroups()
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return Enumerable.Empty<GroupDto>();
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return Enumerable.Empty<GroupDto>();
@@ -91,13 +101,13 @@ namespace WorldSeed.Api.Controllers
         [HttpGet("{groupId}/members")]
         public IEnumerable<GroupMemberDto> GetGroupMembers(int groupId)
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return Enumerable.Empty<GroupMemberDto>();
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return Enumerable.Empty<GroupMemberDto>();
@@ -116,13 +126,13 @@ namespace WorldSeed.Api.Controllers
         [HttpPost("join")]
         public StatusCodeResult JoinGroup(JoinGroupRequestDto joinDto)
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
@@ -140,13 +150,13 @@ namespace WorldSeed.Api.Controllers
         [HttpPost("leave")]
         public StatusCodeResult LeaveGroup(JoinGroupRequestDto dto)
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
@@ -160,13 +170,13 @@ namespace WorldSeed.Api.Controllers
         [HttpPost("updateName")]
         public StatusCodeResult UpdateGroupName(UpdateGroupNameDto dto)
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
@@ -180,13 +190,13 @@ namespace WorldSeed.Api.Controllers
         [HttpPost("rank")]
         public StatusCodeResult ChangeRank(ChangeMemberRankDto dto)
         {
-            var claimValue = User.FindFirst(ClaimTypes.Name)?.Value;
-            if (!int.TryParse(claimValue, out var accountId))
+            var accountId = GetAccountIdFromClaims();
+            if (!accountId.HasValue)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            var account = _accountService.GetAccountById(accountId);
+            var account = _accountService.GetAccountById(accountId.Value);
             if (account == null || account.DefaultUser == null)
             {
                 return StatusCode(StatusCodes.Status400BadRequest);

--- a/Tests/WorldSeed.Tests/GroupControllerTests.cs
+++ b/Tests/WorldSeed.Tests/GroupControllerTests.cs
@@ -1,0 +1,66 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using WorldSeed.Api.Controllers;
+using WorldSeed.Application.DTOS;
+using WorldSeed.Application.Interfaces.Services;
+using WorldSeed.Domain.Entities.AccountRelated;
+using WorldSeed.Domain.Entities.UserRelated;
+using WorldSeed.Domain.Entities.GroupRelated;
+
+namespace WorldSeed.Tests;
+
+public class GroupControllerTests
+{
+    private class StubGroupService : IGroupService
+    {
+        public Group CreateGroup(string name, long userId) => new Group { Id = 1, Name = name };
+        public IEnumerable<Group> GetGroupsForUser(long userId) => throw new NotImplementedException();
+        public IEnumerable<Group> GetJoinableGroups(long userId) => throw new NotImplementedException();
+        public IEnumerable<GroupMember> GetGroupMembers(int groupId) => throw new NotImplementedException();
+        public GroupMember JoinGroup(int groupId, long userId) => throw new NotImplementedException();
+        public bool LeaveGroup(int groupId, long userId) => throw new NotImplementedException();
+        public bool UpdateGroupName(int groupId, string newName, long actorUserId) => throw new NotImplementedException();
+        public bool ChangeMemberRank(int groupId, long actorUserId, long targetUserId, GroupRank newRank) => throw new NotImplementedException();
+    }
+
+    private class StubAccountService : IAccountService
+    {
+        public Account GetAccountById(int accountId) => new Account { Id = accountId, DefaultUser = new User { Id = 2, Name = "user" } };
+        public Account CreateAccount(string username, string email, byte[] passwordHash, byte[] passwordSalt) => throw new NotImplementedException();
+        public Account CheckLoginByEmail(string email, string password) => throw new NotImplementedException();
+        public Account GetAccountByEmail(string email) => throw new NotImplementedException();
+        public Account GetAccountByUsername(string username) => throw new NotImplementedException();
+        public void UpdateTokens(int accountId, string refreshToken, DateTime expires, DateTime created) => throw new NotImplementedException();
+        public User? GetDefaultUser(int accountId) => new User { Id = 2, Name = "user" };
+        public bool SetDefaultUser(int accountId, int userId) => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void CreateGroup_WithAccountIdClaim_ReturnsCreated()
+    {
+        var controller = new GroupController(new StubGroupService(), new StubAccountService());
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("accountId", "1") }))
+            }
+        };
+
+        var result = controller.CreateGroup(new CreateGroupRequestDto { Name = "MyGroup" });
+
+        Assert.Equal(StatusCodes.Status201Created, result.StatusCode);
+    }
+
+    [Fact]
+    public void CreateGroup_WithoutAccountIdClaim_ReturnsBadRequest()
+    {
+        var controller = new GroupController(new StubGroupService(), new StubAccountService());
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new ClaimsIdentity()) } };
+
+        var result = controller.CreateGroup(new CreateGroupRequestDto { Name = "MyGroup" });
+
+        Assert.Equal(StatusCodes.Status400BadRequest, result.StatusCode);
+    }
+}

--- a/Tests/WorldSeed.Tests/TokenServiceTests.cs
+++ b/Tests/WorldSeed.Tests/TokenServiceTests.cs
@@ -4,6 +4,8 @@ using WorldSeed.Application.Interfaces.Services;
 using WorldSeed.Application.DTOS;
 using WorldSeed.Domain.Entities.AccountRelated;
 using WorldSeed.Domain.Entities.UserRelated;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 
 namespace WorldSeed.Tests;
 
@@ -83,6 +85,20 @@ public class TokenServiceTests
 
         Assert.False(service.IsRefreshTokenValid(1, "abc"));
         Assert.False(service.IsRefreshTokenValid(1, "other"));
+    }
+
+    [Fact]
+    public void CreateToken_IncludesAccountIdClaim()
+    {
+        var service = CreateService(new Account());
+
+        var tokenDto = service.CreateToken(5);
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(tokenDto.Token);
+
+        var claim = jwt.Claims.FirstOrDefault(c => c.Type == "accountId");
+        Assert.NotNull(claim);
+        Assert.Equal("5", claim!.Value);
     }
 }
 


### PR DESCRIPTION
## Summary
- use `accountId` claim when determining authenticated account in all controllers
- keep tokens with `accountId` claim and add tests for claim presence
- add basic `GroupController` unit tests for create group

## Testing
- `dotnet test Src/WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_6851e056b4c0832d9d1bc9ed100ed807