### PR TITLE
Fix default user retrieval in account service

### DIFF
--- a/Src/Infrastructure/WorldSeed.Persistence/Services/AccountService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/AccountService.cs
@@ -88,7 +88,12 @@ namespace WorldSeed.Persistence.Services
         }
         public Account GetAccountById(int accountId)
         {
-            return _unitOfwork.Accounts.Get(accountId);
+            var account = _unitOfwork.Accounts.Get(accountId);
+            if (account != null && account.DefaultUserId.HasValue)
+            {
+                account.DefaultUser = _unitOfwork.Users.Get(account.DefaultUserId.Value);
+            }
+            return account;
         }
 
         private bool VerifyPasswordHash(string password, byte[] passwordHash, byte[] passwordSalt)
@@ -113,10 +118,8 @@ namespace WorldSeed.Persistence.Services
 
         public User? GetDefaultUser(int accountId)
         {
-            return _unitOfwork.Accounts.GetAll()
-                .Where(a => a.Id == accountId)
-                .Select(a => a.DefaultUser)
-                .FirstOrDefault();
+            var account = GetAccountById(accountId);
+            return account?.DefaultUser;
         }
 
         public bool SetDefaultUser(int accountId, int userId)

--- a/Tests/WorldSeed.Tests/AccountServiceTests.cs
+++ b/Tests/WorldSeed.Tests/AccountServiceTests.cs
@@ -130,5 +130,37 @@ public class AccountServiceTests
         Assert.True(result);
         Assert.Equal(user.Id, context.Accounts.First().DefaultUserId);
     }
+
+    [Fact]
+    public void GetDefaultUser_ShouldReturnUser()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+        var userService = new UserService(new UnitOfWork(context));
+        var user = userService.CreateUser(account.Id, "u1");
+
+        var fetched = service.GetDefaultUser(account.Id);
+
+        Assert.NotNull(fetched);
+        Assert.Equal(user.Id, fetched!.Id);
+    }
+
+    [Fact]
+    public void GetAccountById_ShouldPopulateDefaultUser()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+        var userService = new UserService(new UnitOfWork(context));
+        var user = userService.CreateUser(account.Id, "u1");
+
+        var fetched = service.GetAccountById(account.Id);
+
+        Assert.NotNull(fetched!.DefaultUser);
+        Assert.Equal(user.Id, fetched.DefaultUser!.Id);
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure AccountService loads the DefaultUser navigation property when fetching an account
- simplify GetDefaultUser to use GetAccountById
- test GetDefaultUser and GetAccountById to confirm DefaultUser is populated

## Testing
- `dotnet test Src/WorldSeed.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851e48db6f4832da1f565bae90c1462