### PR TITLE
Fix group retrieval null reference

### DIFF
--- a/Src/Core/WorldSeed.Application/Interfaces/Repositories/IGroupMemberRepository.cs
+++ b/Src/Core/WorldSeed.Application/Interfaces/Repositories/IGroupMemberRepository.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using WorldSeed.Domain.Entities.GroupRelated;
 
 namespace WorldSeed.Application.Interfaces.Repositories
 {
     public interface IGroupMemberRepository : IRepository<GroupMember>
     {
+        IEnumerable<GroupMember> GetMembersWithGroups(long userId);
     }
 }

--- a/Src/Infrastructure/WorldSeed.Infrastructure/Repositories/GroupMemberRepository.cs
+++ b/Src/Infrastructure/WorldSeed.Infrastructure/Repositories/GroupMemberRepository.cs
@@ -1,3 +1,6 @@
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
 using WorldSeed.Domain.Entities.GroupRelated;
 using WorldSeed.Application.Interfaces.Repositories;
 using WorldSeed.Infrastructure.Data;
@@ -13,6 +16,14 @@ namespace WorldSeed.Infrastructure.Repositories
         ApplicationDbContext ApplicationDbContext
         {
             get { return Context as ApplicationDbContext; }
+        }
+
+        public IEnumerable<GroupMember> GetMembersWithGroups(long userId)
+        {
+            return ApplicationDbContext.GroupMembers
+                .Include(m => m.Group)
+                .Where(m => m.User.Id == userId)
+                .ToList();
         }
     }
 }

--- a/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
@@ -166,15 +166,17 @@ namespace WorldSeed.Persistence.Services
         public IEnumerable<Group> GetGroupsForUser(long userId)
         {
             return _unitOfwork.GroupMembers
-                .Find(m => m.User.Id == userId)
-                .Select(m => m.Group);
+                .GetMembersWithGroups(userId)
+                .Where(m => m.Group != null)
+                .Select(m => m.Group!);
         }
 
         public IEnumerable<Group> GetJoinableGroups(long userId)
         {
             var joinedIds = _unitOfwork.GroupMembers
-                .Find(m => m.User.Id == userId)
-                .Select(m => m.Group.Id)
+                .GetMembersWithGroups(userId)
+                .Where(m => m.Group != null)
+                .Select(m => m.Group!.Id)
                 .ToHashSet();
 
             return _unitOfwork.Groups.GetAll()


### PR DESCRIPTION
## Summary
- load group info when querying membership
- use safe group lookup in GroupService

## Testing
- `dotnet build Src/WorldSeed.sln -c Release`
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6851e6822c14832da95855db29a76725