### PR TITLE
Fix group member retrieval and add unit tests

### DIFF
--- a/Src/Core/WorldSeed.Application/Interfaces/Repositories/IGroupMemberRepository.cs
+++ b/Src/Core/WorldSeed.Application/Interfaces/Repositories/IGroupMemberRepository.cs
@@ -6,5 +6,6 @@ namespace WorldSeed.Application.Interfaces.Repositories
     public interface IGroupMemberRepository : IRepository<GroupMember>
     {
         IEnumerable<GroupMember> GetMembersWithGroups(long userId);
+        IEnumerable<GroupMember> GetMembersWithUsers(int groupId);
     }
 }

--- a/Src/Infrastructure/WorldSeed.Infrastructure/Repositories/GroupMemberRepository.cs
+++ b/Src/Infrastructure/WorldSeed.Infrastructure/Repositories/GroupMemberRepository.cs
@@ -25,5 +25,13 @@ namespace WorldSeed.Infrastructure.Repositories
                 .Where(m => m.User.Id == userId)
                 .ToList();
         }
+
+        public IEnumerable<GroupMember> GetMembersWithUsers(int groupId)
+        {
+            return ApplicationDbContext.GroupMembers
+                .Include(m => m.User)
+                .Where(m => m.Group.Id == groupId)
+                .ToList();
+        }
     }
 }

--- a/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/GroupService.cs
@@ -185,7 +185,7 @@ namespace WorldSeed.Persistence.Services
 
         public IEnumerable<GroupMember> GetGroupMembers(int groupId)
         {
-            return _unitOfwork.GroupMembers.Find(m => m.Group.Id == groupId);
+            return _unitOfwork.GroupMembers.GetMembersWithUsers(groupId);
         }
     }
 }

--- a/Tests/WorldSeed.Tests/GroupServiceTests.cs
+++ b/Tests/WorldSeed.Tests/GroupServiceTests.cs
@@ -22,6 +22,14 @@ public class GroupServiceTests
         return new ApplicationDbContext(options);
     }
 
+    private static ApplicationDbContext CreateContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        return new ApplicationDbContext(options);
+    }
+
     [Fact]
     public void CreateGroup_ShouldPersistGroup()
     {
@@ -114,5 +122,87 @@ public class GroupServiceTests
         Assert.True(result);
         var updated = context.GroupMembers.First(m => m.User.Id == member.Id);
         Assert.Equal(GroupRank.Admin, updated.Rank);
+    }
+
+    [Fact]
+    public void GetGroupMembers_AfterOwnerLeavesAndNewUserJoins_ReturnsUsers()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using (var context = CreateContext(dbName))
+        {
+            var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            var newUser = new User { Id = 2, Name = "member", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            context.Users.AddRange(owner, newUser);
+            context.SaveChanges();
+
+            var service = CreateService(context);
+            var group = service.CreateGroup("Group", owner.Id);
+            service.LeaveGroup(group.Id, owner.Id);
+            service.JoinGroup(group.Id, newUser.Id);
+        }
+
+        using (var context = CreateContext(dbName))
+        {
+            var service = CreateService(context);
+            var members = service.GetGroupMembers(context.Groups.First().Id).ToList();
+
+            Assert.Single(members);
+            Assert.NotNull(members[0].User);
+            Assert.Equal("member", members[0].User.Name);
+        }
+    }
+
+    [Fact]
+    public void GetGroupMembers_AfterOwnerLeavesAndRejoins_ReturnsUsers()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using (var context = CreateContext(dbName))
+        {
+            var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            context.Users.Add(owner);
+            context.SaveChanges();
+
+            var service = CreateService(context);
+            var group = service.CreateGroup("Group", owner.Id);
+            service.LeaveGroup(group.Id, owner.Id);
+            service.JoinGroup(group.Id, owner.Id);
+        }
+
+        using (var context = CreateContext(dbName))
+        {
+            var service = CreateService(context);
+            var members = service.GetGroupMembers(context.Groups.First().Id).ToList();
+
+            Assert.Single(members);
+            Assert.NotNull(members[0].User);
+            Assert.Equal("owner", members[0].User.Name);
+        }
+    }
+
+    [Fact]
+    public void GetGroupMembers_AfterNewUserLeaves_ReturnsOwnerOnly()
+    {
+        var dbName = Guid.NewGuid().ToString();
+        using (var context = CreateContext(dbName))
+        {
+            var owner = new User { Id = 1, Name = "owner", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            var newUser = new User { Id = 2, Name = "member", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+            context.Users.AddRange(owner, newUser);
+            context.SaveChanges();
+
+            var service = CreateService(context);
+            var group = service.CreateGroup("Group", owner.Id);
+            service.JoinGroup(group.Id, newUser.Id);
+            service.LeaveGroup(group.Id, newUser.Id);
+        }
+
+        using (var context = CreateContext(dbName))
+        {
+            var service = CreateService(context);
+            var members = service.GetGroupMembers(context.Groups.First().Id).ToList();
+
+            Assert.Single(members);
+            Assert.Equal("owner", members[0].User.Name);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure group member retrieval loads related users
- expose new repository method `GetMembersWithUsers`
- test group membership retrieval when users join, leave, or rejoin groups

## Testing
- `dotnet test Tests/WorldSeed.Tests/WorldSeed.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6851ea59ff4c832db05c4e1f3176aba0