### PR TITLE
Fix UpdateTokens null account check

### DIFF
--- a/Src/Infrastructure/WorldSeed.Persistence/Services/AccountService.cs
+++ b/Src/Infrastructure/WorldSeed.Persistence/Services/AccountService.cs
@@ -107,7 +107,12 @@ namespace WorldSeed.Persistence.Services
 
         public void UpdateTokens(int accountId, string refreshToken, DateTime expires, DateTime created)
         {
-            var account = _unitOfwork.Accounts.GetAll().Where(u => u.Id.Equals(accountId)).FirstOrDefault();
+            var account = _unitOfwork.Accounts.GetAll()
+                .FirstOrDefault(u => u.Id.Equals(accountId));
+            if (account == null)
+            {
+                return;
+            }
 
             account.RefreshToken = refreshToken;
             account.TokenExpires = expires;

--- a/Tests/WorldSeed.Tests/AccountServiceTests.cs
+++ b/Tests/WorldSeed.Tests/AccountServiceTests.cs
@@ -116,6 +116,24 @@ public class AccountServiceTests
     }
 
     [Fact]
+    public void UpdateTokens_InvalidId_DoesNothing()
+    {
+        using var context = CreateContext();
+        var service = CreateService(context);
+        var (hash, salt) = Hash("pass");
+        var account = service.CreateAccount("user", "user@example.com", hash, salt);
+
+        var expires = DateTime.UtcNow.AddHours(1);
+        var created = DateTime.UtcNow;
+        service.UpdateTokens(account.Id + 1, "token", expires, created);
+
+        var unchanged = context.Accounts.First();
+        Assert.Equal(string.Empty, unchanged.RefreshToken);
+        Assert.Equal(default, unchanged.TokenExpires);
+        Assert.Equal(default, unchanged.TokenCreated);
+    }
+
+    [Fact]
     public void SetDefaultUser_ShouldUpdateDefaultUser()
     {
         using var context = CreateContext();


### PR DESCRIPTION
## Summary
- ensure UpdateTokens returns early when no account is found
- add a regression test for this behaviour

## Testing
- `dotnet test Src/WorldSeed.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852af9bf1f0832dab28ad8d14146626