### PR TITLE
Refactor password hashing

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Authentication Helpers/IPasswordHasher.cs
+++ b/Src/Presentation/WorldSeed.Api/Authentication Helpers/IPasswordHasher.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace WorldSeed.Api.Temp
+{
+    public interface IPasswordHasher
+    {
+        void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt);
+    }
+}

--- a/Src/Presentation/WorldSeed.Api/Authentication Helpers/PasswordHasher.cs
+++ b/Src/Presentation/WorldSeed.Api/Authentication Helpers/PasswordHasher.cs
@@ -1,0 +1,14 @@
+using System.Security.Cryptography;
+
+namespace WorldSeed.Api.Temp
+{
+    public class PasswordHasher : IPasswordHasher
+    {
+        public void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt)
+        {
+            using var hmac = new HMACSHA512();
+            passwordSalt = hmac.Key;
+            passwordHash = hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password));
+        }
+    }
+}

--- a/Src/Presentation/WorldSeed.Api/Controllers/AuthController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/AuthController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Cryptography;
 using WorldSeed.Api.Temp;
 using WorldSeed.Application.DTOS;
 using WorldSeed.Application.Interfaces.Services;
@@ -20,12 +19,14 @@ namespace WorldSeed.Api.Controllers
         private readonly IConfiguration _configuration;
         private readonly IAccountService _accountService;
         private readonly ITokenService _tokenService;
+        private readonly IPasswordHasher _passwordHasher;
 
-        public AuthController(IConfiguration configuration, IAccountService accountService, ITokenService tokenService)
+        public AuthController(IConfiguration configuration, IAccountService accountService, ITokenService tokenService, IPasswordHasher passwordHasher)
         {
             _configuration = configuration;
             _accountService = accountService;
             _tokenService = tokenService;
+            _passwordHasher = passwordHasher;
         }
 
         [HttpPost("register")]
@@ -39,7 +40,7 @@ namespace WorldSeed.Api.Controllers
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            CreatePasswordHash(request.Password, out byte[] passwordHash, out byte[] passwordSalt);
+            _passwordHasher.CreatePasswordHash(request.Password, out byte[] passwordHash, out byte[] passwordSalt);
 
             var resultCreate =_accountService.CreateAccount(request.Username, request.Email, passwordHash, passwordSalt);
 
@@ -118,16 +119,6 @@ namespace WorldSeed.Api.Controllers
             };
 
             return Ok(refreshTokenResponseDTO);
-        }
-
-        // TODO: Move this out of AuthController
-        private void CreatePasswordHash(string password, out byte[] passwordHash, out byte[] passwordSalt)
-        {
-            using (var hmac = new HMACSHA512())
-            {
-                passwordSalt = hmac.Key;
-                passwordHash = hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password));
-            }
         }
 
     }

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddTransient<IGroupService, GroupService>();
 builder.Services.AddTransient<IForumService, ForumService>();
 
 builder.Services.AddTransient<ITokenService, TokenService>();
+builder.Services.AddTransient<IPasswordHasher, PasswordHasher>();
 
 
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/Tests/WorldSeed.Tests/PasswordHasherTests.cs
+++ b/Tests/WorldSeed.Tests/PasswordHasherTests.cs
@@ -1,0 +1,31 @@
+using WorldSeed.Api.Temp;
+
+namespace WorldSeed.Tests;
+
+public class PasswordHasherTests
+{
+    [Fact]
+    public void CreatePasswordHash_GeneratesDifferentSaltEachCall()
+    {
+        var hasher = new PasswordHasher();
+
+        hasher.CreatePasswordHash("pass", out var hash1, out var salt1);
+        hasher.CreatePasswordHash("pass", out var hash2, out var salt2);
+
+        Assert.NotEqual(Convert.ToBase64String(salt1), Convert.ToBase64String(salt2));
+        Assert.NotEqual(Convert.ToBase64String(hash1), Convert.ToBase64String(hash2));
+    }
+
+    [Fact]
+    public void CreatePasswordHash_CanBeVerifiedWithSameSalt()
+    {
+        var hasher = new PasswordHasher();
+
+        hasher.CreatePasswordHash("pass", out var hash, out var salt);
+
+        using var hmac = new System.Security.Cryptography.HMACSHA512(salt);
+        var expected = hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes("pass"));
+
+        Assert.Equal(expected, hash);
+    }
+}


### PR DESCRIPTION
## Summary
- make password hashing a service
- inject `IPasswordHasher` into AuthController
- register service in Program.cs
- test password hasher behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852afa6a3a4832dba6a34ba00912bd2