### PR TITLE
Rename method in ForumController

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Controllers/ForumController.cs
+++ b/Src/Presentation/WorldSeed.Api/Controllers/ForumController.cs
@@ -21,7 +21,7 @@ namespace WorldSeed.Api.Controllers
         }
 
         [HttpPost("createForum")]
-        public StatusCodeResult CreateGroup(CreateForumDTO createForumDTO)
+        public StatusCodeResult CreateForum(CreateForumDTO createForumDTO)
         {
             if (!_forumService.CreateForum(createForumDTO.Name, createForumDTO.GroupId))
             {


### PR DESCRIPTION
## Summary
- rename `CreateGroup` method to `CreateForum`

## Testing
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6852afa812fc832daa659ba21c193257