### PR TITLE
Fix refresh token null account check

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
+++ b/Src/Presentation/WorldSeed.Api/Authentication Helpers/TokenService.cs
@@ -65,12 +65,14 @@ namespace WorldSeed.Api.Temp
         {
             var account = _accountService.GetAccountById(accountId);
 
-            if (account.RefreshToken == refreshToken)
+            if (account == null)
             {
-                if(account.TokenExpires > DateTime.UtcNow)
-                {
-                    return true;
-                }
+                return false;
+            }
+
+            if (account.RefreshToken == refreshToken && account.TokenExpires > DateTime.UtcNow)
+            {
+                return true;
             }
 
             return false;

--- a/Tests/WorldSeed.Tests/TokenServiceTests.cs
+++ b/Tests/WorldSeed.Tests/TokenServiceTests.cs
@@ -30,6 +30,18 @@ public class TokenServiceTests
         public bool SetDefaultUser(int accountId, int userId) => throw new NotImplementedException();
     }
 
+    private class NullAccountService : IAccountService
+    {
+        public Account GetAccountById(int accountId) => null;
+        public Account CreateAccount(string username, string email, byte[] passwordHash, byte[] passwordSalt) => throw new NotImplementedException();
+        public Account CheckLoginByEmail(string email, string password) => throw new NotImplementedException();
+        public Account GetAccountByEmail(string email) => throw new NotImplementedException();
+        public Account GetAccountByUsername(string username) => throw new NotImplementedException();
+        public void UpdateTokens(int accountId, string refreshToken, DateTime expires, DateTime created) => throw new NotImplementedException();
+        public User? GetDefaultUser(int accountId) => null;
+        public bool SetDefaultUser(int accountId, int userId) => throw new NotImplementedException();
+    }
+
     private static TokenService CreateService(Account account)
     {
         var settings = new Dictionary<string, string> { { "AppSettings:Token", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } };
@@ -85,6 +97,17 @@ public class TokenServiceTests
 
         Assert.False(service.IsRefreshTokenValid(1, "abc"));
         Assert.False(service.IsRefreshTokenValid(1, "other"));
+    }
+
+    [Fact]
+    public void IsRefreshTokenValid_NoAccount_ReturnsFalse()
+    {
+        var settings = new Dictionary<string, string> { { "AppSettings:Token", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } };
+        IConfiguration config = new ConfigurationBuilder().AddInMemoryCollection(settings!).Build();
+        var accSvc = new NullAccountService();
+        var service = new TokenService(config, accSvc);
+
+        Assert.False(service.IsRefreshTokenValid(1, "abc"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- avoid NRE in `TokenService.IsRefreshTokenValid`
- add NullAccountService stub for tests
- test that missing accounts are invalid refresh tokens

## Testing
- `dotnet test Src/WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_6852afa92db0832d932109f7b85780bb