### PR TITLE
Add Docker support for Render deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/bin
+**/obj
+.git
+Dockerfile
+**/*.user
+Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# copy csproj and restore as distinct layers
+COPY Src/WorldSeed.sln ./
+COPY Src/Common/WorldSeed.Common/WorldSeed.Common.csproj Src/Common/WorldSeed.Common/
+COPY Src/Core/WorldSeed.Domain/WorldSeed.Domain.csproj Src/Core/WorldSeed.Domain/
+COPY Src/Core/WorldSeed.Application/WorldSeed.Application.csproj Src/Core/WorldSeed.Application/
+COPY Src/Infrastructure/WorldSeed.Infrastructure/WorldSeed.Infrastructure.csproj Src/Infrastructure/WorldSeed.Infrastructure/
+COPY Src/Infrastructure/WorldSeed.Persistence/WorldSeed.Persistence.csproj Src/Infrastructure/WorldSeed.Persistence/
+COPY Src/Presentation/WorldSeed.Api/WorldSeed.Api.csproj Src/Presentation/WorldSeed.Api/
+RUN dotnet restore WorldSeed.sln
+
+# copy everything else and publish
+COPY . .
+RUN dotnet publish Src/Presentation/WorldSeed.Api/WorldSeed.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+# Application listens on port 8080 by default
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "WorldSeed.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ To execute the unit tests run:
 ```bash
 dotnet test Src/WorldSeed.sln -c Release
 ```
+
+## Docker deployment on Render.com
+
+A `Dockerfile` is provided to containerize the API for deployment. Build and run with:
+
+```bash
+docker build -t worldseed .
+docker run -p 8080:8080 worldseed
+```
+
+The container listens on port `8080`. On Render, set the service port to `8080` and use the `Docker` deployment option.


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running the API in a container
- ignore build artifacts in `.dockerignore`
- update README with Docker usage instructions

## Testing
- `dotnet test Src/WorldSeed.sln`

------
https://chatgpt.com/codex/tasks/task_e_685dad3866c0832da2f7f90f38c4f2d0