### PR TITLE
Fix Docker build path issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ WORKDIR /src
 
 # copy csproj and restore as distinct layers
 COPY Src/WorldSeed.sln ./
-COPY Src/Common/WorldSeed.Common/WorldSeed.Common.csproj Src/Common/WorldSeed.Common/
-COPY Src/Core/WorldSeed.Domain/WorldSeed.Domain.csproj Src/Core/WorldSeed.Domain/
-COPY Src/Core/WorldSeed.Application/WorldSeed.Application.csproj Src/Core/WorldSeed.Application/
-COPY Src/Infrastructure/WorldSeed.Infrastructure/WorldSeed.Infrastructure.csproj Src/Infrastructure/WorldSeed.Infrastructure/
-COPY Src/Infrastructure/WorldSeed.Persistence/WorldSeed.Persistence.csproj Src/Infrastructure/WorldSeed.Persistence/
-COPY Src/Presentation/WorldSeed.Api/WorldSeed.Api.csproj Src/Presentation/WorldSeed.Api/
+COPY Src/Common/WorldSeed.Common/WorldSeed.Common.csproj Common/WorldSeed.Common/
+COPY Src/Core/WorldSeed.Domain/WorldSeed.Domain.csproj Core/WorldSeed.Domain/
+COPY Src/Core/WorldSeed.Application/WorldSeed.Application.csproj Core/WorldSeed.Application/
+COPY Src/Infrastructure/WorldSeed.Infrastructure/WorldSeed.Infrastructure.csproj Infrastructure/WorldSeed.Infrastructure/
+COPY Src/Infrastructure/WorldSeed.Persistence/WorldSeed.Persistence.csproj Infrastructure/WorldSeed.Persistence/
+COPY Src/Presentation/WorldSeed.Api/WorldSeed.Api.csproj Presentation/WorldSeed.Api/
+COPY Tests/WorldSeed.Tests/WorldSeed.Tests.csproj ../Tests/WorldSeed.Tests/
 RUN dotnet restore WorldSeed.sln
 
 # copy everything else and publish


### PR DESCRIPTION
## Summary
- fix Docker build stage to copy project files in expected locations
- include test project when restoring

## Testing
- `dotnet restore Src/WorldSeed.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685daeec7e10832d92e494e7606bd8f5