### PR TITLE
Fix Docker build by including test project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,5 @@
 .git
 Dockerfile
 **/*.user
-Tests
+Tests/*
+!Tests/WorldSeed.Tests/WorldSeed.Tests.csproj


### PR DESCRIPTION
## Summary
- update `.dockerignore` to allow `WorldSeed.Tests.csproj`

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `docker build -t worldseed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685db150b6e0832d9e38e0b33d471a99