### PR TITLE
Fix port binding for Render

### DIFF
--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -21,10 +21,18 @@ var initialConfig = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .Build();
 
-var apiUrl = initialConfig.GetValue<string>("ApiSettings:Url");
-if (!string.IsNullOrWhiteSpace(apiUrl))
+var port = Environment.GetEnvironmentVariable("PORT");
+if (!string.IsNullOrWhiteSpace(port))
 {
-    Environment.SetEnvironmentVariable("ASPNETCORE_URLS", apiUrl);
+    Environment.SetEnvironmentVariable("ASPNETCORE_URLS", $"http://0.0.0.0:{port}");
+}
+else
+{
+    var apiUrl = initialConfig.GetValue<string>("ApiSettings:Url");
+    if (!string.IsNullOrWhiteSpace(apiUrl))
+    {
+        Environment.SetEnvironmentVariable("ASPNETCORE_URLS", apiUrl);
+    }
 }
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
## Summary
- ensure port binding honors environment variables so Render can detect the app

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f08e43d34832db6fafdd6bbb8d5f2