### PR TITLE
Make container port configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 COPY --from=build /app/publish .
 
-# Application listens on port 8080 by default
-ENV ASPNETCORE_URLS=http://0.0.0.0:8080
+# Application listens on the port specified by $PORT
+ENV ASPNETCORE_URLS=http://0.0.0.0:${PORT}
 EXPOSE 8080
 
 ENTRYPOINT ["dotnet", "WorldSeed.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A `Dockerfile` is provided to containerize the API for deployment. Build and run
 
 ```bash
 docker build -t worldseed .
-docker run -p 8080:8080 worldseed
+docker run -e PORT=8080 -p 8080:8080 worldseed
 ```
 
-The container listens on port `8080`. On Render, set the service port to `8080` and use the `Docker` deployment option.
+The container listens on the port specified by the `PORT` environment variable. On Render, set `PORT` (e.g., `8080`) and use the `Docker` deployment option.


### PR DESCRIPTION
## Summary
- update Dockerfile to use `$PORT` instead of hard-coding 8080
- document how to set the `PORT` variable when running the container

## Testing
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6860791f0d5c832da599ce47a8b738e7