### PR TITLE
Switch to Fly.io on port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 COPY --from=build /app/publish .
 
-# Application listens on the port specified by $PORT
-ENV ASPNETCORE_URLS=http://0.0.0.0:${PORT}
+# Application listens on port 8080
+ENV ASPNETCORE_URLS=http://0.0.0.0:8080
 EXPOSE 8080
 
 ENTRYPOINT ["dotnet", "WorldSeed.Api.dll"]

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ To execute the unit tests run:
 dotnet test Src/WorldSeed.sln -c Release
 ```
 
-## Docker deployment on Render.com
+## Deployment on Fly.io
 
-A `Dockerfile` is provided to containerize the API for deployment. Build and run with:
+A `Dockerfile` is provided to containerize the API. Build and run locally with:
 
 ```bash
 docker build -t worldseed .
-docker run -e PORT=8080 -p 8080:8080 worldseed
+docker run -p 8080:8080 worldseed
 ```
 
-The container listens on the port specified by the `PORT` environment variable. On Render, set `PORT` (e.g., `8080`) and use the `Docker` deployment option. `app.UseHttpsRedirection()` is automatically disabled when `PORT` is detected so the service can run behind Render's TLS proxy without errors.
+The service listens on port `8080`. When deploying to Fly.io, ensure `fly.toml` sets the `internal_port` to `8080` so incoming traffic is forwarded correctly.

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -21,19 +21,10 @@ var initialConfig = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .Build();
 
-var port = Environment.GetEnvironmentVariable("PORT");
-var isPortConfigured = !string.IsNullOrWhiteSpace(port);
-if (isPortConfigured)
+var apiUrl = initialConfig.GetValue<string>("ApiSettings:Url");
+if (!string.IsNullOrWhiteSpace(apiUrl))
 {
-    Environment.SetEnvironmentVariable("ASPNETCORE_URLS", $"http://0.0.0.0:{port}");
-}
-else
-{
-    var apiUrl = initialConfig.GetValue<string>("ApiSettings:Url");
-    if (!string.IsNullOrWhiteSpace(apiUrl))
-    {
-        Environment.SetEnvironmentVariable("ASPNETCORE_URLS", apiUrl);
-    }
+    Environment.SetEnvironmentVariable("ASPNETCORE_URLS", apiUrl);
 }
 
 var builder = WebApplication.CreateBuilder(args);
@@ -108,10 +99,7 @@ if (app.Environment.IsDevelopment())
     app.UseCors("DevelopmentModeCors");
 }
 
-if (!isPortConfigured)
-{
-    app.UseHttpsRedirection();
-}
+app.UseHttpsRedirection();
 
 app.UseAuthentication();
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,10 @@
+app = "worldseed-app"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  ASPNETCORE_URLS = "http://0.0.0.0:8080"
+
+[http_service]
+  internal_port = 8080


### PR DESCRIPTION
## Summary
- drop Render.com deployment info and add Fly.io guidance
- set Docker port to 8080
- provide `fly.toml` sample configured for port 8080
- simplify Program.cs port handling (from previous PR)

## Testing
- `dotnet test Src/WorldSeed.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863041dae64832d82ed0143f5a8653a