### PR TITLE
Update API port to 8080

### DIFF
--- a/Src/Presentation/WorldSeed.Api/appsettings.Development.json
+++ b/Src/Presentation/WorldSeed.Api/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ApiSettings": {
-    "Url": "http://localhost:5048"
+    "Url": "http://localhost:8080"
   }
 }

--- a/Src/Presentation/WorldSeed.Api/appsettings.json
+++ b/Src/Presentation/WorldSeed.Api/appsettings.json
@@ -3,7 +3,7 @@
     "Token": "REPLACEp8QGgjVyP9gkAAyTDD04POfaRGeeVB3hDQNMEF832ft6oC1-JjcYsoOAcb4p-CR5RHpYzyXNdvGhKYA"
   },
   "ApiSettings": {
-    "Url": "http://localhost:5048"
+    "Url": "http://localhost:8080"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- change API port setting from 5048 to 8080 for Fly.io compatibility

## Testing
- `dotnet test Src/WorldSeed.sln`


------
https://chatgpt.com/codex/tasks/task_e_686307404f30832d830845e94da88b4d