### PR TITLE
Make API listen on all interfaces

### DIFF
--- a/Src/Presentation/WorldSeed.Api/appsettings.Development.json
+++ b/Src/Presentation/WorldSeed.Api/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ApiSettings": {
-    "Url": "http://localhost:8080"
+    "Url": "http://0.0.0.0:8080"
   }
 }

--- a/Src/Presentation/WorldSeed.Api/appsettings.json
+++ b/Src/Presentation/WorldSeed.Api/appsettings.json
@@ -3,7 +3,7 @@
     "Token": "REPLACEp8QGgjVyP9gkAAyTDD04POfaRGeeVB3hDQNMEF832ft6oC1-JjcYsoOAcb4p-CR5RHpYzyXNdvGhKYA"
   },
   "ApiSettings": {
-    "Url": "http://localhost:8080"
+    "Url": "http://0.0.0.0:8080"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- change default API URL to 0.0.0.0 in appsettings

## Testing
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6863095d3d50832d97424f73e77429dd