### PR TITLE
Expose Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ docker run -p 8080:8080 worldseed
 ```
 
 The service listens on port `8080`. When deploying to Fly.io, ensure `fly.toml` sets the `internal_port` to `8080` so incoming traffic is forwarded correctly.
+
+Swagger UI is enabled in all environments. Visiting the root URL or `/swagger` shows the interactive API documentation.

--- a/Src/Presentation/WorldSeed.Api/Program.cs
+++ b/Src/Presentation/WorldSeed.Api/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using WorldSeed.Api.Temp;
 using WorldSeed.Application.Interfaces;
@@ -91,11 +92,11 @@ builder.Services.AddCors(options =>
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
+app.UseSwagger();
+app.UseSwaggerUI();
+
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
-
     app.UseCors("DevelopmentModeCors");
 }
 
@@ -106,5 +107,11 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+
+app.MapGet("/", context =>
+{
+    context.Response.Redirect("/swagger");
+    return Task.CompletedTask;
+});
 
 app.Run();


### PR DESCRIPTION
## Summary
- enable Swagger for all environments
- redirect root path to `/swagger`
- document new Swagger endpoint

## Testing
- `dotnet test Src/WorldSeed.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68630d232a78832d9d6344b5167d2ee6